### PR TITLE
[Flutter] 식물 일지 API 연동

### DIFF
--- a/frontend/reactweb/src/api/chatbot.ts
+++ b/frontend/reactweb/src/api/chatbot.ts
@@ -1,6 +1,9 @@
 import { axiosInterface } from "api";
 const postChat = async (question: string) => {
-  const { data } = await axiosInterface.post("/api/chatbot", { question });
+  const { data } = await axiosInterface.post("/api/member/chatbot", {
+    question,
+  });
+  alert(data);
   return data;
 };
 

--- a/frontend/reactweb/src/api/diary.ts
+++ b/frontend/reactweb/src/api/diary.ts
@@ -18,13 +18,17 @@ interface putDiaryProps {
 const DIARY_URL = "/api/member/diary";
 
 const getDiaryList = async ({ year, month }: getDiaryListProps) => {
-  const { data } = await axiosInterface.get(`${DIARY_URL}/monthly`, {
-    params: {
-      year,
-      month,
-    },
-  });
-  return data;
+  try {
+    const { data } = await axiosInterface.get(`${DIARY_URL}/monthly`, {
+      params: {
+        year,
+        month,
+      },
+    });
+    return data;
+  } catch (e: any) {
+    return [];
+  }
 };
 
 const postDiary = async ({

--- a/frontend/reactweb/src/api/index.ts
+++ b/frontend/reactweb/src/api/index.ts
@@ -2,15 +2,15 @@ import axios from "axios";
 
 const axiosInterface = axios.create({
   baseURL: "http://msds-capstone.store",
-  timeout: 10000,
+  timeout: 100000,
 });
 
 axiosInterface.interceptors.request.use(
   (config) => {
-    // const token = localStorage.getItem("token");
-    // if (token) {
-    //   config.headers["Authorization"] = `Bearer ${token}`;
-    // }
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers["Authorization"] = `Bearer ${token}`;
+    }
     return Promise.resolve(config);
   },
   (error) => {

--- a/frontend/reactweb/src/components/Home/TopSection.tsx
+++ b/frontend/reactweb/src/components/Home/TopSection.tsx
@@ -13,6 +13,7 @@ export default function TopSection() {
         <StyledDiagnoseBar>
           <StyledDiagnoseTxt>식물 질병을 진단해보세요!</StyledDiagnoseTxt>
           <StyledCameraBtn>
+            <RequestCamera type="file" accept="image/*" capture />
             <Camera />
           </StyledCameraBtn>
         </StyledDiagnoseBar>
@@ -59,12 +60,22 @@ const StyledDiagnoseTxt = styled.h5`
   color: ${COLOR.FONT_GRAY_BA};
 `;
 const StyledCameraBtn = styled.button`
+  position: relative;
   width: 4.8rem;
   height: 4.8rem;
   border-radius: 1.8rem;
   padding: 1.2rem;
   background-color: white;
   box-shadow: 0px 3px 5px 0px rgba(13, 63, 103, 0.1);
+`;
+
+const RequestCamera = styled.input`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
 `;
 const StyledDiseaseContainer = styled.div`
   margin-top: 2rem;

--- a/frontend/reactweb/src/components/PlantDiary/Calendar.tsx
+++ b/frontend/reactweb/src/components/PlantDiary/Calendar.tsx
@@ -4,16 +4,42 @@ import CalendarItem from "components/PlantDiary/CalendarItem";
 import { ReactComponent as PlusIcon } from "assets/icons/icon_plus.svg";
 import { FONT_STYLES } from "styles/fontStyle";
 import getCalendar from "utils/getCalendar";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Routes from "router/Routes";
+interface listType {
+  id: number;
+  createDate: string;
+  title: string;
+  author: string;
+  color: string;
+  plantName: string;
+  contents: string;
+}
 interface calendarProps {
   currYM: { month: number; year: number };
+  list: listType[] | [];
 }
-export default function Calendar({ currYM }: calendarProps) {
+
+const getlistbyDate = (diaries: listType[] | []) => {
+  const initial: { [date: number]: listType[] } = {};
+  diaries.forEach((diary) => {
+    const date = new Date(diary.createDate).getDate();
+    if (!initial[date]) {
+      initial[date] = [];
+    }
+    initial[date].push(diary);
+  });
+  return initial;
+};
+export default function Calendar({ currYM, list }: calendarProps) {
   const DAYS = ["일", "월", "화", "수", "목", "금", "토"];
   const navigate = useNavigate();
+  const [listBydate, setListByDate] = useState<{ [date: number]: listType[] }>(
+    {}
+  );
   const [selDate, setSelDate] = useState(new Date().getDate());
+  useEffect(() => setListByDate(getlistbyDate(list)), [list]);
   const curDateTxt = useMemo(() => {
     const strYear = String(currYM.year).slice(-2);
     const strMonth = String(currYM.month).padStart(2, "0");
@@ -22,10 +48,10 @@ export default function Calendar({ currYM }: calendarProps) {
     const strDay = DAYS[day];
     return `${strYear}.${strMonth}.${strDate} (${strDay})`;
   }, [currYM, selDate]);
-
   const onSelect = (date: number | null) => {
     if (date) setSelDate(date);
   };
+
   return (
     <StyledContainer>
       <StyledCalendar>
@@ -47,7 +73,11 @@ export default function Calendar({ currYM }: calendarProps) {
                   >
                     {date}
                     <StyledSpotContainer>
-                      {/* <StyledSpot color="red" /> */}
+                      {date &&
+                        listBydate[date] &&
+                        listBydate[date].map(({ color }: listType) => (
+                          <StyledSpot color={color} key={color} />
+                        ))}
                     </StyledSpotContainer>
                   </StyledDate>
                 ))}
@@ -64,9 +94,10 @@ export default function Calendar({ currYM }: calendarProps) {
           </StyledBtn>
         </StyledPreviewHeader>
         <StyledPreviewContent>
-          <CalendarItem />
-          <CalendarItem />
-          <CalendarItem />
+          {listBydate[selDate] &&
+            listBydate[selDate].map(({ title, plantName, color }) => (
+              <CalendarItem {...{ color, plantName, title }} />
+            ))}
         </StyledPreviewContent>
       </StyledPreview>
     </StyledContainer>

--- a/frontend/reactweb/src/components/PlantDiary/CalendarItem.tsx
+++ b/frontend/reactweb/src/components/PlantDiary/CalendarItem.tsx
@@ -1,12 +1,20 @@
 import styled from "styled-components";
 import Tag from "components/common/Tag";
 import { FONT_STYLES } from "styles/fontStyle";
-
-export default function CalendarItem() {
+interface calendarItemProps {
+  title: string;
+  plantName: string;
+  color: string;
+}
+export default function CalendarItem({
+  title,
+  plantName,
+  color,
+}: calendarItemProps) {
   return (
     <StyledContainer>
-      <StyledTitle>고구마 식물일지 3일차</StyledTitle>
-      <Tag type="고구마" color="#863241" />
+      <StyledTitle>{title}</StyledTitle>
+      <Tag type={plantName} color={color} />
     </StyledContainer>
   );
 }

--- a/frontend/reactweb/src/components/PlantDiary/Diary.tsx
+++ b/frontend/reactweb/src/components/PlantDiary/Diary.tsx
@@ -4,27 +4,27 @@ import Tag from "components/common/Tag";
 import { FONT_STYLES } from "styles/fontStyle";
 interface diaryProps {
   title: string;
-  date: string;
-  content: string;
-  tag: string;
+  createDate: string;
+  contents: string;
+  plantName: string;
   color: string;
 }
 export default function Diary({
   title,
-  date,
-  content,
-  tag,
+  createDate,
+  contents,
+  plantName,
   color,
 }: diaryProps) {
   return (
     <StyledDiaryContainer>
       <StyledDiary>
         <StyledTitle>{title}</StyledTitle>
-        <StyledDate>{date}</StyledDate>
-        <StyledContent>{content}</StyledContent>
+        <StyledDate>{createDate}</StyledDate>
+        <StyledContent>{contents}</StyledContent>
       </StyledDiary>
       <StyledTag>
-        <Tag type={tag} color={color} />
+        <Tag type={plantName} color={color} />
       </StyledTag>
     </StyledDiaryContainer>
   );

--- a/frontend/reactweb/src/components/PlantDiary/DiaryList.tsx
+++ b/frontend/reactweb/src/components/PlantDiary/DiaryList.tsx
@@ -3,7 +3,19 @@ import CommonBtn from "components/common/CommonBtn";
 import Diary from "components/PlantDiary/Diary";
 import Routes from "router/Routes";
 import { useNavigate } from "react-router-dom";
-export default function DiaryList() {
+interface listType {
+  id: number;
+  createDate: string;
+  title: string;
+  author: string;
+  color: string;
+  plantName: string;
+  contents: string;
+}
+interface diaryListProps {
+  list: listType[] | [];
+}
+export default function DiaryList({ list }: diaryListProps) {
   const diaryTxt = {
     title: "고구마 식물일지",
     date: "2021년 07월 21일(월) 오후 24:00",
@@ -14,8 +26,9 @@ export default function DiaryList() {
   const navigate = useNavigate();
   return (
     <StContainer>
-      <Diary {...diaryTxt} />
-      <Diary {...diaryTxt} />
+      {list.map(({ createDate, title, color, plantName, contents }) => (
+        <Diary {...{ createDate, title, color, plantName, contents }} />
+      ))}
       <StyledBtnContainer>
         <CommonBtn label="글쓰기" handler={() => navigate(Routes.DiaryWrite)} />
       </StyledBtnContainer>

--- a/frontend/reactweb/src/views/Chatbot.tsx
+++ b/frontend/reactweb/src/views/Chatbot.tsx
@@ -121,7 +121,7 @@ const StyledInput = styled.input`
   background: transparent;
   flex-grow: 1;
   color: ${COLOR.FONT_BLACK_24};
-  font-size: 1.5rem;
+  font-size: 1.6rem;
   ${FONT_STYLES.PR_R}
 `;
 

--- a/frontend/reactweb/src/views/DiaryEdit.tsx
+++ b/frontend/reactweb/src/views/DiaryEdit.tsx
@@ -4,18 +4,35 @@ import Header from "components/common/Header";
 import { FONT_STYLES } from "styles/fontStyle";
 import Tag from "components/common/Tag";
 import CommonBtn from "components/common/CommonBtn";
+import { useRef } from "react";
+import { postDiary } from "api/diary";
 export default function DiaryEdit() {
+  const dateRef = useRef<HTMLInputElement>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const textArea = useRef<HTMLTextAreaElement>(null);
+  const handleSubmit = () => {
+    const title = titleRef.current?.value;
+    const contents = textArea.current?.value;
+    const date = textArea.current?.value;
+    if (title && contents && date) {
+      postDiary({
+        title,
+        plantName: "고구마",
+        contents,
+      });
+    }
+  };
   return (
     <StyledContainer>
       <Header title="일기 작성" icon="previous" />
       <StyledMain>
         <div>
           <StyledInputLabel>날짜</StyledInputLabel>
-          <StyledInput type="date" />
+          <StyledInput type="date" ref={dateRef} />
         </div>
         <div>
           <StyledInputLabel>제목</StyledInputLabel>
-          <StyledInput placeholder="제목을 입력해주세요" />
+          <StyledInput placeholder="제목을 입력해주세요" ref={titleRef} />
         </div>
         <div>
           <StyledInputLabel>작물종</StyledInputLabel>
@@ -25,11 +42,11 @@ export default function DiaryEdit() {
         </div>
         <div className="grow-flex">
           <StyledInputLabel>내용</StyledInputLabel>
-          <StyledTextArea />
+          <StyledTextArea ref={textArea} />
         </div>
       </StyledMain>
       <StyledBtnContainer>
-        <CommonBtn label="저장" />
+        <CommonBtn label="저장" handler={handleSubmit} />
       </StyledBtnContainer>
     </StyledContainer>
   );

--- a/frontend/reactweb/src/views/PlantDiary.tsx
+++ b/frontend/reactweb/src/views/PlantDiary.tsx
@@ -5,15 +5,29 @@ import SelectBtn from "components/PlantDiary/SelectBtn";
 import { ReactComponent as RightArrow } from "assets/icons/icon_right-arrow.svg";
 import { ReactComponent as LeftArrow } from "assets/icons/icon_left-arrow.svg";
 import { FONT_STYLES } from "styles/fontStyle";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import DiaryList from "components/PlantDiary/DiaryList";
 import Calendar from "components/PlantDiary/Calendar";
+import { getDiaryList } from "api/diary";
 export default function PlantDiary() {
   const btnTxts = ["달력", "일기"];
+  const [totalList, setTotalList] = useState([]);
   const [curState, setCurState] = useState(btnTxts[0]);
   const [curDate, setCurDate] = useState(new Date());
   const nxtMonth = useMemo(() => curDate.getMonth() + 1, [curDate]);
   const preMonth = useMemo(() => curDate.getMonth() - 1, [curDate]);
+  const getTotalList = async () => {
+    const totalList = await getDiaryList({
+      year: curDate.getFullYear(),
+      month: curDate.getMonth() + 1,
+    });
+
+    setTotalList(totalList?.diaries);
+  };
+  useEffect(() => {
+    getTotalList();
+  }, [curDate]);
+
   const currYM = {
     year: curDate.getFullYear(),
     month: curDate.getMonth() + 1,
@@ -22,6 +36,7 @@ export default function PlantDiary() {
     const nxtMonthDate = new Date(curDate.setMonth(month));
     setCurDate(nxtMonthDate);
   };
+
   return (
     <StyledDiaryWrapper>
       <Header title="식물일지" icon="menu" />
@@ -36,7 +51,11 @@ export default function PlantDiary() {
           {currYM.year}년 {currYM.month}월
           <RightArrow onClick={() => setMonth(nxtMonth)} />
         </StyledSelectDate>
-        {curState === "달력" ? <Calendar currYM={currYM} /> : <DiaryList />}
+        {curState === "달력" ? (
+          <Calendar currYM={currYM} list={totalList} />
+        ) : (
+          <DiaryList list={totalList} />
+        )}
       </StyledDiaryContainer>
     </StyledDiaryWrapper>
   );


### PR DESCRIPTION
##  식물일지 API 연동

### 관련 ISSUE: #22 

### 변경 사항

- 식물 일지 받아오기 API 구현
- 식물 일지 저장 API 구현
- 식물 일지 달력/ 리스트 별 기능 구현

### 포인트

list 변경 시와 첫 렌더링 시마다
 오는 해당 달 일지들을 날짜 별 배열로 변경

```ts
const getlistbyDate = (diaries: listType[] | []) => {
  const initial: { [date: number]: listType[] } = {};
  diaries.forEach((diary) => {
    const date = new Date(diary.createDate).getDate();
    if (!initial[date]) {
      initial[date] = [];
    }
    initial[date].push(diary);
  });
  return initial;
};

const [listBydate, setListByDate] = useState<{ [date: number]: listType[] }>({});

useEffect(() => setListByDate(getlistbyDate(list)), [list]);
```


