### PR TITLE
[식물일지] 식물 일지 수정 및 삭제 기능 추가

### DIFF
--- a/frontend/reactweb/src/assets/json/modalTxt.json
+++ b/frontend/reactweb/src/assets/json/modalTxt.json
@@ -22,5 +22,9 @@
   "plantDeleteFail": {
     "contents": "식물 삭제에 실패하였습니다.",
     "btnTxt": ["확인"]
+  },
+  "diaryDelete": {
+    "contents": "일기를 삭제하시겠습니까?",
+    "btnTxt": ["취소", "확인"]
   }
 }

--- a/frontend/reactweb/src/components/common/Menu.tsx
+++ b/frontend/reactweb/src/components/common/Menu.tsx
@@ -45,7 +45,7 @@ const menuLinks = [
   {
     txt: "설정",
     Icon: SettingIcon,
-    link: "/",
+    link: "/kakao/login",
   },
 ];
 

--- a/frontend/reactweb/src/components/common/TagDropDown.tsx
+++ b/frontend/reactweb/src/components/common/TagDropDown.tsx
@@ -5,8 +5,10 @@ import styled from "styled-components";
 
 export default function TagDropDown({
   handler,
+  selectedPlant,
 }: {
-  handler: (plantname: string) => void;
+  handler: (plantname: string, plantcolor: string) => void;
+  selectedPlant?: { color: string; name: string };
 }) {
   useEffect(() => {
     setPlants();
@@ -24,21 +26,19 @@ export default function TagDropDown({
     const plants = await getPlants();
     setPlantList(plants.plantList);
   };
-  const [selectedTag, setSelectedTag] = useState<plantType>();
   const [plantList, setPlantList] = useState<plantType[] | null>();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const handleTagSelect = (plant: plantType) => {
-    setSelectedTag(plant);
     setIsOpen(false);
-    handler(plant.name);
+    handler(plant.name, plant.color);
   };
   return (
     <StyledTagDropDown>
       <StyledSelectedTag onClick={() => setIsOpen(true)}>
         {plantList && (
           <Tag
-            color={selectedTag?.color ?? plantList[0].color}
-            type={selectedTag?.name ?? plantList[0].name}
+            color={selectedPlant?.color ?? plantList[0].color}
+            type={selectedPlant?.name ?? plantList[0].name}
           ></Tag>
         )}
       </StyledSelectedTag>

--- a/frontend/reactweb/src/views/DiaryDetail.tsx
+++ b/frontend/reactweb/src/views/DiaryDetail.tsx
@@ -5,12 +5,17 @@ import { FONT_STYLES } from "styles/fontStyle";
 import Tag from "components/common/Tag";
 import CommonBtn from "components/common/CommonBtn";
 import { useEffect, useState } from "react";
-import { getDiary } from "api/diary";
+import { delDiary, getDiary } from "api/diary";
 import { useParams } from "react-router-dom";
 import { fromJSONtoDateStr } from "utils/getDate";
+import { useNavigate } from "react-router-dom";
+import ModalTxtJSON from "assets/json/modalTxt.json";
 import TagDropDown from "components/common/TagDropDown";
+import Routes from "router/Routes";
+import CommonModal from "components/common/CommonModal";
 export default function DiaryDetail() {
   const params = useParams();
+  const navigate = useNavigate();
   interface contentsType {
     id: number;
     createDate: string;
@@ -33,6 +38,11 @@ export default function DiaryDetail() {
     const diaryDetail = await getDiary(Number(params.id));
     setContents(diaryDetail as contentsType);
   };
+  const deleteDiary = async () => {
+    await delDiary(contents.id);
+    navigate(Routes.Diary);
+  };
+  const [modalActive, setModalActive] = useState<boolean>(false);
   useEffect(() => {
     setDiaryDetail();
   }, []);
@@ -46,9 +56,31 @@ export default function DiaryDetail() {
         <StyledContent>{contents.contents}</StyledContent>
       </StyledMain>
       <StyledBtnContainer>
-        <CommonBtn label="삭제" theme="delete" />
-        <CommonBtn label="수정" />
+        <CommonBtn
+          label="삭제"
+          theme="delete"
+          handler={() => {
+            setModalActive(true);
+          }}
+        />
+        <CommonBtn
+          label="수정"
+          handler={() => {
+            navigate(`/diary/edit/${contents.id}`);
+          }}
+        />
       </StyledBtnContainer>
+      {modalActive && (
+        <CommonModal
+          {...ModalTxtJSON.diaryDelete}
+          confirmHandler={() => {
+            deleteDiary();
+          }}
+          cancelHandler={() => {
+            setModalActive(false);
+          }}
+        />
+      )}
     </StyledContainer>
   );
 }


### PR DESCRIPTION
### 관련 ISSUE

#22 


### 변경 사항

- useRef로 가져오던 input 값들에 default value를 줘야했으므로(일기 내용) state로 변경
- 임시적으로 설정 아이콘에 카카오 로그인 라우팅 추가
- 태그 설정 placeholder 설정 필요, 이후 구현 예정
- api 두번씩 요청하는 에러 발견, 이후 수정 예정
